### PR TITLE
Change theme colors from gold-black to red-white gradient

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -63,29 +63,29 @@ const Dashboard: React.FC = () => {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-96">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-red-600"></div>
       </div>
     );
   }
 
   return (
     <div className="space-y-4 sm:space-y-6">
-      <div className="bg-gradient-to-r from-neutral-900 to-amber-600 rounded-xl shadow-sm p-4 sm:p-6 text-white">
+      <div className="bg-gradient-to-r from-red-800 to-red-600 rounded-xl shadow-sm p-4 sm:p-6 text-white">
         <div>
           <h1 className="text-xl sm:text-2xl font-bold">Selamat datang, {userSettings.userName}! 👋</h1>
-          <p className="text-amber-100 mt-1 text-sm sm:text-base">Ringkasan keuangan Anda untuk {getFormattedSelection()}</p>
+          <p className="text-red-100 mt-1 text-sm sm:text-base">Ringkasan keuangan Anda untuk {getFormattedSelection()}</p>
         </div>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
-        <div className="bg-white rounded-xl shadow-sm p-4 sm:p-6 border-l-4 border-amber-600">
+        <div className="bg-white rounded-xl shadow-sm p-4 sm:p-6 border-l-4 border-red-600">
           <div className="flex items-center justify-between">
             <div className="min-w-0 flex-1">
               <p className="text-xs sm:text-sm font-medium text-gray-600 truncate">Pemasukan {getFormattedSelection()}</p>
               <p className="text-lg sm:text-2xl font-bold text-gray-900 break-words">{formatCurrency(totalIncome)}</p>
             </div>
-            <div className="bg-amber-100 p-2 sm:p-3 rounded-full flex-shrink-0 ml-2">
-              <ArrowUp className="h-5 w-5 sm:h-6 sm:w-6 text-amber-700" />
+            <div className="bg-red-100 p-2 sm:p-3 rounded-full flex-shrink-0 ml-2">
+              <ArrowUp className="h-5 w-5 sm:h-6 sm:w-6 text-red-700" />
             </div>
           </div>
         </div>
@@ -106,7 +106,7 @@ const Dashboard: React.FC = () => {
           <div className="flex items-center justify-between">
             <div className="min-w-0 flex-1">
               <p className="text-xs sm:text-sm font-medium text-gray-600">Saldo</p>
-              <p className={`text-lg sm:text-2xl font-bold break-words ${totalIncome - totalExpense >= 0 ? 'text-amber-700' : 'text-red-600'}`}>
+              <p className={`text-lg sm:text-2xl font-bold break-words ${totalIncome - totalExpense >= 0 ? 'text-red-700' : 'text-red-600'}`}>
                 {formatCurrency(totalIncome - totalExpense)}
               </p>
             </div>
@@ -134,7 +134,7 @@ const Dashboard: React.FC = () => {
                     </p>
                   </div>
                   <div className="text-right">
-                    <p className="text-sm font-semibold text-amber-700">
+                    <p className="text-sm font-semibold text-red-700">
                       {tp.percentage.toFixed(0)}%
                     </p>
                     <p className="text-xs text-gray-500">
@@ -157,7 +157,7 @@ const Dashboard: React.FC = () => {
           </h2>
           <button
             onClick={() => setIsModalOpen(true)}
-            className="w-full bg-gradient-to-r from-neutral-900 to-amber-600 text-white py-3 px-4 rounded-lg hover:from-emerald-600 hover:to-blue-700 transition-all duration-200 font-medium flex items-center justify-center space-x-2"
+            className="w-full bg-gradient-to-r from-red-800 to-red-600 text-white py-3 px-4 rounded-lg hover:from-red-700 hover:to-red-800 transition-all duration-200 font-medium flex items-center justify-center space-x-2"
           >
             <Plus className="h-5 w-5" />
             <span>Tambah Transaksi Baru</span>
@@ -174,10 +174,10 @@ const Dashboard: React.FC = () => {
                 <div key={transaction.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                   <div className="flex items-center space-x-3">
                     <div className={`p-2 rounded-full ${
-                      transaction.type === 'income' ? 'bg-amber-100' : 'bg-red-100'
+                      transaction.type === 'income' ? 'bg-red-100' : 'bg-red-100'
                     }`}>
                       {transaction.type === 'income' ? (
-                        <ArrowUp className={`h-4 w-4 text-amber-700`} />
+                        <ArrowUp className={`h-4 w-4 text-red-700`} />
                       ) : (
                         <ArrowDown className={`h-4 w-4 text-red-600`} />
                       )}
@@ -189,7 +189,7 @@ const Dashboard: React.FC = () => {
                   </div>
                   <div className="text-right">
                     <p className={`font-semibold ${
-                      transaction.type === 'income' ? 'text-amber-700' : 'text-red-600'
+                      transaction.type === 'income' ? 'text-red-700' : 'text-red-600'
                     }`}>
                       {transaction.type === 'income' ? '+' : '-'}{formatCurrency(transaction.amount)}
                     </p>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -82,7 +82,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         onClick={onClick}
         className={`flex items-center space-x-3 px-4 py-3 rounded-lg transition-all duration-200 ${
           isActive
-            ? 'bg-gradient-to-r from-neutral-900 to-amber-600 text-white shadow-md transform scale-[0.98]'
+            ? 'bg-gradient-to-r from-red-800 to-red-600 text-white shadow-md transform scale-[0.98]'
             : 'text-gray-700 hover:bg-gray-100 hover:text-gray-900 hover:scale-[0.98]'
         }`}
       >
@@ -110,7 +110,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         aria-label={`Navigasi ke ${item.label}`}
         className={`flex flex-col items-center space-y-0.5 sm:space-y-1 px-1.5 sm:px-2 py-1 sm:py-1.5 rounded-lg transition-all duration-200 min-w-0 flex-1 max-w-[72px] touch-target ${
           isActive
-            ? 'text-amber-700 bg-amber-50 shadow-sm'
+            ? 'text-red-700 bg-red-50 shadow-sm'
             : 'text-gray-500 hover:text-gray-700 hover:bg-gray-50 active:bg-gray-100 active:scale-95'
         }`}
       >
@@ -143,7 +143,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
     <div className={bgImage ? "min-h-screen flex flex-col" : "min-h-screen bg-gradient-to-br from-neutral-950 to-neutral-900 flex flex-col"} style={wrapperStyle}>
       {/* Mobile Header */}
-      <header className="bg-gradient-to-r from-neutral-900 to-amber-600 shadow-lg lg:hidden flex-shrink-0">
+      <header className="bg-gradient-to-r from-red-800 to-red-600 shadow-lg lg:hidden flex-shrink-0">
         <div className="px-3 sm:px-4 py-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-2 sm:space-x-3">
@@ -157,7 +157,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 </Button>
               </SheetTrigger>
               <SheetContent side="left" className="w-72 p-0">
-                <SheetHeader className="p-6 bg-gradient-to-r from-neutral-900 to-amber-600 text-white">
+                <SheetHeader className="p-6 bg-gradient-to-r from-red-800 to-red-600 text-white">
                   <SheetTitle className="text-white">
                     <span>W2 CORP</span>
                   </SheetTitle>
@@ -183,7 +183,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
       </header>
 
       {/* Desktop Header */}
-      <header className="bg-gradient-to-r from-neutral-900 to-amber-600 shadow-lg hidden lg:block flex-shrink-0">
+      <header className="bg-gradient-to-r from-red-800 to-red-600 shadow-lg hidden lg:block flex-shrink-0">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <div className="flex items-center space-x-3">

--- a/src/components/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt.tsx
@@ -78,8 +78,8 @@ const PWAInstallPrompt: React.FC = () => {
     <div className="fixed bottom-4 left-4 right-4 bg-white border border-gray-200 rounded-lg shadow-lg p-4 z-50 md:left-auto md:right-4 md:max-w-sm">
       <div className="flex items-start justify-between">
         <div className="flex items-center space-x-3">
-          <div className="bg-amber-100 p-2 rounded-full">
-            <Download className="h-5 w-5 text-amber-700" />
+          <div className="bg-red-100 p-2 rounded-full">
+            <Download className="h-5 w-5 text-red-700" />
           </div>
           <div>
             <h3 className="font-semibold text-gray-900">Install Gaji-ku</h3>

--- a/src/components/ResponsiveDashboard.tsx
+++ b/src/components/ResponsiveDashboard.tsx
@@ -142,13 +142,13 @@ const ResponsiveDashboard: React.FC = () => {
     if (percentage > 100) return { color: 'text-red-600', bg: 'bg-red-500', status: 'Melebihi batas!' };
     if (percentage === 100) return { color: 'text-orange-600', bg: 'bg-orange-500', status: 'Mencapai batas' };
     if (percentage >= 80) return { color: 'text-orange-600', bg: 'bg-orange-500', status: 'Mendekati batas' };
-    return { color: 'text-amber-700', bg: 'bg-emerald-500', status: 'Dalam batas' };
+    return { color: 'text-red-700', bg: 'bg-emerald-500', status: 'Dalam batas' };
   };
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-96">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-red-600"></div>
       </div>
     );
   }
@@ -157,23 +157,23 @@ const ResponsiveDashboard: React.FC = () => {
   return (
     <div className="space-y-4 sm:space-y-6 pb-20 lg:pb-0">
       {/* Welcome Message */}
-      <div className="bg-gradient-to-r from-neutral-900 to-amber-600 rounded-xl shadow-sm p-4 sm:p-6 text-white">
+      <div className="bg-gradient-to-r from-red-800 to-red-600 rounded-xl shadow-sm p-4 sm:p-6 text-white">
         <div>
           <h1 className="text-xl sm:text-2xl font-bold">Selamat datang, {userSettings.userName}! 👋</h1>
-          <p className="text-amber-100 mt-1 text-sm sm:text-base">Ringkasan keuangan Anda untuk {getFormattedSelection()}</p>
+          <p className="text-red-100 mt-1 text-sm sm:text-base">Ringkasan keuangan Anda untuk {getFormattedSelection()}</p>
         </div>
       </div>
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3 sm:gap-4 xl:gap-6">
-        <div className="bg-white rounded-xl shadow-sm p-3 lg:p-4 xl:p-6 border-l-4 border-amber-600">
+        <div className="bg-white rounded-xl shadow-sm p-3 lg:p-4 xl:p-6 border-l-4 border-red-600">
           <div className="flex items-center justify-between">
             <div className="min-w-0 flex-1">
               <p className="text-xs sm:text-sm font-medium text-gray-600 truncate">Pemasukan {getFormattedSelection()}</p>
               <p className="text-base md:text-xl xl:text-2xl font-bold text-gray-900 truncate">{formatCurrency(totalIncome)}</p>
             </div>
-            <div className="bg-amber-100 p-2 sm:p-3 rounded-full flex-shrink-0 ml-2">
-              <ArrowUp className="h-5 w-5 sm:h-6 sm:w-6 text-amber-700" />
+            <div className="bg-red-100 p-2 sm:p-3 rounded-full flex-shrink-0 ml-2">
+              <ArrowUp className="h-5 w-5 sm:h-6 sm:w-6 text-red-700" />
             </div>
           </div>
         </div>
@@ -194,7 +194,7 @@ const ResponsiveDashboard: React.FC = () => {
           <div className="flex items-center justify-between">
             <div className="min-w-0 flex-1">
               <p className="text-xs sm:text-sm font-medium text-gray-600 truncate">Saldo</p>
-              <p className={`text-base md:text-xl xl:text-2xl font-bold truncate ${totalIncome - totalExpense >= 0 ? 'text-amber-700' : 'text-red-600'}`}>
+              <p className={`text-base md:text-xl xl:text-2xl font-bold truncate ${totalIncome - totalExpense >= 0 ? 'text-red-700' : 'text-red-600'}`}>
                 {formatCurrency(totalIncome - totalExpense)}
               </p>
             </div>
@@ -268,7 +268,7 @@ const ResponsiveDashboard: React.FC = () => {
                       </p>
                     </div>
                     <div className="text-right flex-shrink-0">
-                      <p className="text-sm font-semibold text-amber-700">
+                      <p className="text-sm font-semibold text-red-700">
                         {tp.percentage.toFixed(0)}%
                       </p>
                       <p className="text-xs text-gray-500">
@@ -348,7 +348,7 @@ const ResponsiveDashboard: React.FC = () => {
           </h2>
           <button
             onClick={() => setIsModalOpen(true)}
-            className="w-full bg-gradient-to-r from-neutral-900 to-amber-600 text-white py-3 px-4 rounded-lg hover:from-emerald-600 hover:to-blue-700 transition-all duration-200 font-medium flex items-center justify-center space-x-2"
+            className="w-full bg-gradient-to-r from-red-800 to-red-600 text-white py-3 px-4 rounded-lg hover:from-red-700 hover:to-red-800 transition-all duration-200 font-medium flex items-center justify-center space-x-2"
           >
             <Plus className="h-4 w-4 sm:h-5 sm:w-5" />
             <span className="text-sm sm:text-base">Tambah Transaksi Baru</span>
@@ -366,10 +366,10 @@ const ResponsiveDashboard: React.FC = () => {
                 <div key={transaction.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                   <div className="flex items-center space-x-2 sm:space-x-3 min-w-0 flex-1">
                     <div className={`p-1.5 sm:p-2 rounded-full flex-shrink-0 ${
-                      transaction.type === 'income' ? 'bg-amber-100' : 'bg-red-100'
+                      transaction.type === 'income' ? 'bg-red-100' : 'bg-red-100'
                     }`}>
                       {transaction.type === 'income' ? (
-                        <ArrowUp className={`h-3 w-3 sm:h-4 sm:w-4 text-amber-700`} />
+                        <ArrowUp className={`h-3 w-3 sm:h-4 sm:w-4 text-red-700`} />
                       ) : (
                         <ArrowDown className={`h-3 w-3 sm:h-4 sm:w-4 text-red-600`} />
                       )}
@@ -381,7 +381,7 @@ const ResponsiveDashboard: React.FC = () => {
                   </div>
                   <div className="text-right flex-shrink-0 ml-2">
                     <p className={`font-semibold text-sm sm:text-base ${
-                      transaction.type === 'income' ? 'text-amber-700' : 'text-red-600'
+                      transaction.type === 'income' ? 'text-red-700' : 'text-red-600'
                     }`}>
                       {transaction.type === 'income' ? '+' : '-'}{formatCurrency(transaction.amount)}
                     </p>

--- a/src/components/TransactionForm.tsx
+++ b/src/components/TransactionForm.tsx
@@ -66,9 +66,9 @@ const TransactionForm: React.FC<TransactionFormProps> = ({ categories, onTransac
             value="income"
             checked={formData.type === 'income'}
             onChange={(e) => setFormData({ ...formData, type: e.target.value as 'income' | 'expense', category: '' })}
-            className="mr-2 text-amber-700"
+            className="mr-2 text-red-700"
           />
-          <span className="text-amber-700 font-medium">Pemasukan</span>
+          <span className="text-red-700 font-medium">Pemasukan</span>
         </label>
         <label className="flex items-center">
           <input
@@ -90,7 +90,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({ categories, onTransac
           type="number"
           value={formData.amount}
           onChange={(e) => setFormData({ ...formData, amount: e.target.value })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-amber-600 focus:border-amber-600"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-red-600 focus:border-red-600"
           placeholder="0"
           required
         />
@@ -104,7 +104,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({ categories, onTransac
           type="text"
           value={formData.description}
           onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-amber-600 focus:border-amber-600"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-red-600 focus:border-red-600"
           placeholder="Contoh: Makan siang"
           required
         />
@@ -118,7 +118,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({ categories, onTransac
           <select
             value={formData.category}
             onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-amber-600 focus:border-amber-600"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-red-600 focus:border-red-600"
             required
           >
             <option value="">Pilih kategori pemasukan</option>
@@ -139,14 +139,14 @@ const TransactionForm: React.FC<TransactionFormProps> = ({ categories, onTransac
           type="date"
           value={formData.date}
           onChange={(e) => setFormData({ ...formData, date: e.target.value })}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-amber-600 focus:border-amber-600"
+          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-red-600 focus:border-red-600"
           required
         />
       </div>
 
       <button
         type="submit"
-        className="w-full bg-gradient-to-r from-neutral-900 to-amber-600 text-white py-2 px-4 rounded-lg hover:from-emerald-600 hover:to-blue-700 transition-all duration-200 font-medium"
+        className="w-full bg-gradient-to-r from-red-800 to-red-600 text-white py-2 px-4 rounded-lg hover:from-red-700 hover:to-red-800 transition-all duration-200 font-medium"
       >
         Tambah Transaksi
       </button>

--- a/src/components/TransactionFormModal.tsx
+++ b/src/components/TransactionFormModal.tsx
@@ -226,10 +226,10 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({
                     value="income"
                     checked={formData.type === 'income'}
                     onChange={(e) => handleTypeChange(e.target.value as 'income')}
-                    className="mr-3 text-amber-700"
+                    className="mr-3 text-red-700"
                     disabled={isLoading}
                   />
-                  <span className="text-amber-700 font-medium text-sm sm:text-base break-words whitespace-normal">
+                  <span className="text-red-700 font-medium text-sm sm:text-base break-words whitespace-normal">
                     💰 Pemasukan
                   </span>
                 </label>
@@ -279,7 +279,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({
                     <select
                       value={formData.category}
                       onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-                      className="w-full px-3 py-3 text-sm sm:text-base border border-gray-300 rounded-lg focus:ring-amber-600 focus:border-amber-600 bg-white"
+                      className="w-full px-3 py-3 text-sm sm:text-base border border-gray-300 rounded-lg focus:ring-red-600 focus:border-red-600 bg-white"
                       required
                       disabled={isLoading}
                     >
@@ -300,7 +300,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({
                           {filteredCategories.map((category, index) => (
                             <span
                               key={`category-badge-${category.id}-${index}`}
-                              className="inline-flex items-center px-2 py-1 rounded-full font-medium break-words bg-amber-100 text-amber-800 text-xs leading-tight"
+                              className="inline-flex items-center px-2 py-1 rounded-full font-medium break-words bg-red-100 text-red-800 text-xs leading-tight"
                               title={category.name}
                             >
                               <span className="break-words max-w-20 leading-tight">
@@ -332,7 +332,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({
                   type="text"
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  className="w-full px-3 py-3 text-sm sm:text-base border border-gray-300 rounded-lg focus:ring-amber-600 focus:border-amber-600"
+                  className="w-full px-3 py-3 text-sm sm:text-base border border-gray-300 rounded-lg focus:ring-red-600 focus:border-red-600"
                   placeholder="Contoh: Makan siang, Gaji bulanan, dll."
                   required={formData.type !== 'transfer_to_target'}
                   disabled={isLoading}
@@ -352,7 +352,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({
                   const formatted = formatInputNumber(e.target.value);
                   setFormData({ ...formData, amount: formatted });
                 }}
-                className="w-full px-3 py-3 text-sm sm:text-base border border-gray-300 rounded-lg focus:ring-amber-600 focus:border-amber-600"
+                className="w-full px-3 py-3 text-sm sm:text-base border border-gray-300 rounded-lg focus:ring-red-600 focus:border-red-600"
                 placeholder="0"
                 required
                 disabled={isLoading}
@@ -368,7 +368,7 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({
                 type="date"
                 value={formData.date}
                 onChange={(e) => setFormData({ ...formData, date: e.target.value })}
-                className="w-full px-3 py-3 text-sm sm:text-base border border-gray-300 rounded-lg focus:ring-amber-600 focus:border-amber-600"
+                className="w-full px-3 py-3 text-sm sm:text-base border border-gray-300 rounded-lg focus:ring-red-600 focus:border-red-600"
                 required
                 disabled={isLoading}
               />
@@ -380,14 +380,14 @@ const TransactionFormModal: React.FC<TransactionFormModalProps> = ({
                 type="button"
                 onClick={onClose}
                 disabled={isLoading}
-                className="flex-1 px-4 py-3 text-sm sm:text-base font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 focus:ring-2 focus:ring-offset-2 focus:ring-amber-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex-1 px-4 py-3 text-sm sm:text-base font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 focus:ring-2 focus:ring-offset-2 focus:ring-red-600 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Batal
               </button>
               <button
                 type="submit"
                 disabled={!isFormValid() || isLoading}
-                className="flex-1 bg-gradient-to-r from-neutral-900 to-amber-600 text-white py-3 px-4 rounded-lg hover:from-emerald-600 hover:to-blue-700 transition-all duration-200 font-medium text-sm sm:text-base disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
+                className="flex-1 bg-gradient-to-r from-red-800 to-red-600 text-white py-3 px-4 rounded-lg hover:from-red-700 hover:to-red-800 transition-all duration-200 font-medium text-sm sm:text-base disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center"
               >
                 {isLoading ? (
                   <>

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -120,7 +120,7 @@ const TransactionList: React.FC<TransactionListProps> = ({
                 <div className="flex items-center space-x-4 min-w-0">
                   <div className={`p-2 rounded-lg ${
                     transaction.type === 'income'
-                      ? 'bg-amber-100 text-amber-700'
+                      ? 'bg-red-100 text-red-700'
                       : transaction.type === 'transfer_to_target'
                       ? 'bg-blue-100 text-blue-600'
                       : 'bg-red-100 text-red-600'
@@ -155,7 +155,7 @@ const TransactionList: React.FC<TransactionListProps> = ({
                 <div className="flex items-center space-x-3 pl-2 flex-shrink-0">
                   <span className={`font-semibold text-sm sm:text-base ${
                     transaction.type === 'income'
-                      ? 'text-amber-700'
+                      ? 'text-red-700'
                       : transaction.type === 'transfer_to_target'
                       ? 'text-blue-600'
                       : 'text-red-600'

--- a/src/components/ui/fixed-save-button.tsx
+++ b/src/components/ui/fixed-save-button.tsx
@@ -48,7 +48,7 @@ export const FixedSaveButton: React.FC<FixedSaveButtonProps> = ({
           form={formId}
           onClick={formId ? undefined : onSave}
           disabled={disabled || isLoading}
-          className="flex-1 bg-gradient-to-r from-neutral-900 to-amber-600 text-white py-3 hover:from-neutral-800 hover:to-amber-700 transition-all duration-200 font-medium text-sm sm:text-base"
+          className="flex-1 bg-gradient-to-r from-red-800 to-red-600 text-white py-3 hover:from-red-700 hover:to-red-800 transition-all duration-200 font-medium text-sm sm:text-base"
         >
           {isLoading ? (
             <>

--- a/src/index.css
+++ b/src/index.css
@@ -96,7 +96,7 @@
 }
 
 .loading-spinner {
-  @apply animate-spin rounded-full border-b-2 border-amber-600;
+  @apply animate-spin rounded-full border-b-2 border-red-600;
 }
 
 .toast-success {
@@ -117,7 +117,7 @@
 }
 
 .focus-ring {
-  @apply focus:outline-none focus:ring-2 focus:ring-amber-600 focus:ring-offset-2;
+  @apply focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2;
 }
 
 /* Mobile-specific utilities */

--- a/src/pages/Target.tsx
+++ b/src/pages/Target.tsx
@@ -17,7 +17,7 @@ const TabunganPage: React.FC = () => {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-96">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-amber-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-red-600"></div>
       </div>
     );
   }
@@ -41,7 +41,7 @@ const TabunganPage: React.FC = () => {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Total Tabungan Bulan Ini</CardTitle>
-            <PiggyBank className="h-4 w-4 text-amber-600" />
+            <PiggyBank className="h-4 w-4 text-red-600" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{formatCurrency(totalSavings)}</div>
@@ -51,7 +51,7 @@ const TabunganPage: React.FC = () => {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Rata-rata per Transaksi</CardTitle>
-            <TrendingUp className="h-4 w-4 text-amber-600" />
+            <TrendingUp className="h-4 w-4 text-red-600" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{formatCurrency(savings.length ? Math.round(totalSavings / savings.length) : 0)}</div>
@@ -61,7 +61,7 @@ const TabunganPage: React.FC = () => {
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Transaksi Terakhir</CardTitle>
-            <PiggyBank className="h-4 w-4 text-amber-600" />
+            <PiggyBank className="h-4 w-4 text-red-600" />
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{savings[0] ? formatCurrency(savings[0].amount) : formatCurrency(0)}</div>

--- a/src/pages/Transaksi.tsx
+++ b/src/pages/Transaksi.tsx
@@ -56,7 +56,7 @@ const Transaksi: React.FC = () => {
           </div>
           <button
             onClick={() => setIsModalOpen(true)}
-            className="flex items-center justify-center space-x-2 bg-gradient-to-r from-neutral-900 to-amber-600 text-white px-4 py-2 rounded-lg hover:from-emerald-600 hover:to-blue-700 transition-all duration-200 font-medium shadow-lg w-full sm:w-auto"
+            className="flex items-center justify-center space-x-2 bg-gradient-to-r from-red-800 to-red-600 text-white px-4 py-2 rounded-lg hover:from-red-700 hover:to-red-800 transition-all duration-200 font-medium shadow-lg w-full sm:w-auto"
           >
             <Plus className="h-4 w-4" />
             <span>Tambah Transaksi</span>


### PR DESCRIPTION
## Purpose
The user requested to change the application's theme from a gold (amber) and black gradient color scheme to a red and white theme. They specifically wanted to ensure the new red theme doesn't clash with existing white menu buttons and fonts, maintaining good visual contrast and readability.

## Code changes
- **Dashboard component**: Updated gradient backgrounds from `from-neutral-900 to-amber-600` to `from-red-800 to-red-600`
- **Layout component**: Changed header and navigation gradients to red theme variants
- **UI components**: Updated loading spinners, icons, and accent colors from amber to red variants
- **Form elements**: Modified focus states and button styles to use red color scheme
- **Transaction indicators**: Changed income transaction colors from amber to red while maintaining expense colors as red
- **Global styles**: Updated CSS classes for loading spinners and focus rings to use red colors

The changes maintain the existing gradient design pattern while replacing all amber/gold colors with appropriate red shades, ensuring proper contrast with white text and UI elements.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/23e565e9fb6e431e93f2b8ceb2752d37/neon-hub)

👀 [Preview Link](https://23e565e9fb6e431e93f2b8ceb2752d37-neon-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>23e565e9fb6e431e93f2b8ceb2752d37</projectId>-->
<!--<branchName>neon-hub</branchName>-->